### PR TITLE
Fix for Cake 2.x, Connection manager::getInstance() is no longer used

### DIFF
--- a/Lib/BeanstalkdSocket.php
+++ b/Lib/BeanstalkdSocket.php
@@ -308,17 +308,18 @@ class BeanstalkdSocket {
 
 		switch ($status) {
 			case 'RESERVED':
-				$id = (integer)strtok(' ');
-				 $length = (integer)strtok(' ');
-				$body = $this->_read($id);
+                $id = (integer)strtok(' ');
+                $length = (integer)strtok(' ');
+                $body = $this->_read($id);
 
-				while (strlen($body) < $length) {
-					$body .= $this->_read($id);
-				}
-				$data = array(
-					'id' => $id,
-					'body' => $body
-				);
+                while (strlen($body) < $length) {
+                    $body .= $this->_read($id);
+                }
+                $data = array(
+                    'id' => $id,
+                    'body' => $body
+                );
+
 				return $data;
 			case 'DEADLINE_SOON':
 			case 'TIMED_OUT':

--- a/Lib/BeanstalkdSocket.php
+++ b/Lib/BeanstalkdSocket.php
@@ -308,19 +308,10 @@ class BeanstalkdSocket {
 
 		switch ($status) {
 			case 'RESERVED':
-                $id = (integer)strtok(' ');
-                $length = (integer)strtok(' ');
-                $body = $this->_read($id);
-
-                while (strlen($body) < $length) {
-                    $body .= $this->_read($id);
-                }
-                $data = array(
-                    'id' => $id,
-                    'body' => $body
-                );
-
-				return $data;
+				return array(
+					'id' => (integer)strtok(' '),
+					'body' => $this->_read((integer)strtok(' '))
+				);
 			case 'DEADLINE_SOON':
 			case 'TIMED_OUT':
 			default:

--- a/Lib/BeanstalkdSocket.php
+++ b/Lib/BeanstalkdSocket.php
@@ -308,10 +308,19 @@ class BeanstalkdSocket {
 
 		switch ($status) {
 			case 'RESERVED':
-				return array(
-					'id' => (integer)strtok(' '),
-					'body' => $this->_read((integer)strtok(' '))
-				);
+                $id = (integer)strtok(' ');
+                $length = (integer)strtok(' ');
+                $body = $this->_read($id);
+
+                while (strlen($body) < $length) {
+                    $body .= $this->_read($id);
+                }
+                $data = array(
+                    'id' => $id,
+                    'body' => $body
+                );
+
+				return $data;
 			case 'DEADLINE_SOON':
 			case 'TIMED_OUT':
 			default:

--- a/Lib/BeanstalkdSocket.php
+++ b/Lib/BeanstalkdSocket.php
@@ -308,18 +308,17 @@ class BeanstalkdSocket {
 
 		switch ($status) {
 			case 'RESERVED':
-                $id = (integer)strtok(' ');
-                $length = (integer)strtok(' ');
-                $body = $this->_read($id);
+				$id = (integer)strtok(' ');
+				 $length = (integer)strtok(' ');
+				$body = $this->_read($id);
 
-                while (strlen($body) < $length) {
-                    $body .= $this->_read($id);
-                }
-                $data = array(
-                    'id' => $id,
-                    'body' => $body
-                );
-
+				while (strlen($body) < $length) {
+					$body .= $this->_read($id);
+				}
+				$data = array(
+					'id' => $id,
+					'body' => $body
+				);
 				return $data;
 			case 'DEADLINE_SOON':
 			case 'TIMED_OUT':

--- a/Lib/BeanstalkdSocket.php
+++ b/Lib/BeanstalkdSocket.php
@@ -203,7 +203,7 @@ class BeanstalkdSocket {
 			if (feof($this->_connection)) {
 				return false;
 			}
-			$data = fread($this->_connection, $length + 2);
+			$data = stream_get_contents($this->_connection, $length + 2);
 			$meta = stream_get_meta_data($this->_connection);
 
 			if ($meta['timed_out']) {
@@ -212,9 +212,7 @@ class BeanstalkdSocket {
 			}
 			$packet = rtrim($data, "\r\n");
 		} else {
-			$data = fgets($this->_connection, 16384);
-			$packet = rtrim($data, "\r\n");
-			//$packet = stream_get_line($this->_connection, 16384, "\r\n");
+			$packet = stream_get_line($this->_connection, 16384, "\r\n");
 		}
 		return $packet;
 	}

--- a/Model/Job.php
+++ b/Model/Job.php
@@ -53,8 +53,12 @@ class Job extends Model {
 		if ($cached && isset($status)) {
 			return $status;
 		}
-		$Manager = ConnectionManager::getInstance();
-		@$DataSource = $Manager->getDataSource($this->useDbConfig);
+
+        try {
+            $DataSource = @ConnectionManager::getDataSource($this->useDbConfig);
+        } catch (\InternalErrorException $e) {
+            return false;
+        }
 
 		return $status = $DataSource && $DataSource->isConnected();
 	}


### PR DESCRIPTION
It also handles the exception if beanstalkd is not available
